### PR TITLE
Ensure Buffer polyfill is registered globally

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
-import 'buffer' // Polyfill for Buffer
+import { Buffer } from 'buffer'
+
+if (typeof globalThis.Buffer === 'undefined') {
+  ;(globalThis as unknown as { Buffer: typeof Buffer }).Buffer = Buffer
+}
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>


### PR DESCRIPTION
## Summary
- register the Buffer polyfill on the global object before rendering the app so the browser runtime can access Buffer

## Testing
- npm run lint *(fails: pre-existing lint issues unrelated to the change)*

------
https://chatgpt.com/codex/tasks/task_b_68d583c3c8ac8326af0c3a7bff941178