### PR TITLE
feat(frontend): add postcss config to fix tailwind styles

### DIFF
--- a/frontend/postcss.config.js
+++ b/frontend/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}


### PR DESCRIPTION
Added a `postcss.config.js` file to the frontend directory. This file explicitly configures PostCSS to use the `tailwindcss` and `autoprefixer` plugins.

This change is necessary to ensure that Tailwind CSS utility classes are correctly processed and applied, resolving the issue where the login page and other components appeared unstyled despite having the correct Tailwind classes in the source code.