### PR TITLE
Adds an index to the conversationId field in the Message model.

### DIFF
--- a/backend/src/models/Message.js
+++ b/backend/src/models/Message.js
@@ -4,7 +4,8 @@ const MessageSchema = new mongoose.Schema({
     conversationId: {
         type: mongoose.Schema.Types.ObjectId,
         ref: 'Conversation',
-        required: true
+        required: true,
+        index: true
     },
     senderId: { // For Sealed Sender, this is optional. The sender is in the ciphertext.
         type: mongoose.Schema.Types.ObjectId,


### PR DESCRIPTION
This is done to improve query performance and prevent full collection scans when fetching messages, which was identified as a critical performance bottleneck.